### PR TITLE
Update gulp-git to v2.4.0 for node 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)",
   "license": "MIT",
   "dependencies": {
-    "gulp-git": "~1.8.0",
+    "gulp-git": "~2.4.0",
     "through2": "^2.0.0"
   },
   "homepage": "https://github.com/lehni/gulp-git-streamed",


### PR DESCRIPTION
@lehni Please check out: https://github.com/stevelacy/gulp-git/releases/tag/gulp-git%402.3.2